### PR TITLE
Added scrollbar for horizontal server list

### DIFF
--- a/personal.scss
+++ b/personal.scss
@@ -24,6 +24,7 @@ $dim-background: 60%;
 $glow-unread-server: false;
 
 $server-list-above: true;
+$server-list-above-enable-scrollbar: true;
 $collapse-member-list: true;
 $status-indicator-border: true;
 $channel-hash-margin: true;
@@ -31,6 +32,7 @@ $code-block-images: true;
 $web-hide-download-button: true;
 $alternative-user-popup: true;
 $compact-mode-tweaks: true;
+$hide-unread-mentions-bar: true;
 $show-loading: true;
 
 $status-indicator-border-thickness: 15px;

--- a/personal.scss
+++ b/personal.scss
@@ -24,7 +24,6 @@ $dim-background: 60%;
 $glow-unread-server: false;
 
 $server-list-above: true;
-$server-list-above-enable-scrollbar: true;
 $collapse-member-list: true;
 $status-indicator-border: true;
 $channel-hash-margin: true;
@@ -32,7 +31,6 @@ $code-block-images: true;
 $web-hide-download-button: true;
 $alternative-user-popup: true;
 $compact-mode-tweaks: true;
-$hide-unread-mentions-bar: true;
 $show-loading: true;
 
 $status-indicator-border-thickness: 15px;

--- a/sakura/_main_code.scss
+++ b/sakura/_main_code.scss
@@ -186,6 +186,9 @@ div[class*="messagesWrapper-"] .scroller-wrap ::-webkit-scrollbar-thumb {
 	border: 1px solid $color-scrollbar-outer!important;
 	border-radius: 999px;
 }
+div[class*="guildsWrapper-"] .scroller-wrap ::-webkit-scrollbar {
+	height: 6px;
+}
 .friends-table div[class*="scrollerWrap-"] ::-webkit-scrollbar-track-piece, 
 div[class*="guildsWrapper-"] .scroller-wrap ::-webkit-scrollbar-track-piece,
 div[class*="messagesWrapper-"] .scroller-wrap ::-webkit-scrollbar-track-piece {

--- a/sakura/_main_code.scss
+++ b/sakura/_main_code.scss
@@ -180,12 +180,14 @@ div[class*="messagesWrapper-"] div[class*="messages-"] div[class*="divider-"] sp
 
 // Scroll bars
 .friends-table div[class*="scrollerWrap-"] ::-webkit-scrollbar-thumb, 
+div[class*="guildsWrapper-"] .scroller-wrap ::-webkit-scrollbar-thumb,
 div[class*="messagesWrapper-"] .scroller-wrap ::-webkit-scrollbar-thumb {
 	background-color: $color-scrollbar-inner!important;
 	border: 1px solid $color-scrollbar-outer!important;
 	border-radius: 999px;
 }
 .friends-table div[class*="scrollerWrap-"] ::-webkit-scrollbar-track-piece, 
+div[class*="guildsWrapper-"] .scroller-wrap ::-webkit-scrollbar-track-piece,
 div[class*="messagesWrapper-"] .scroller-wrap ::-webkit-scrollbar-track-piece {
 	background-color: transparent!important;
 	border: 0;

--- a/tweaks/_main_code.scss
+++ b/tweaks/_main_code.scss
@@ -63,8 +63,11 @@
 
         .scroller-wrap {
             width: 100%;
+        }
+
+        &:hover {
             .scroller {
-                overflow-x: scroll;
+                overflow-x: auto;
                 overflow-y: hidden;
             }
         }

--- a/tweaks/_main_code.scss
+++ b/tweaks/_main_code.scss
@@ -56,13 +56,17 @@
 
     div[class*="guildsWrapper-"] {
         width: 100%;
-        height: 100px;
+        height: 75px;
         @if ($server-list-above-below) {
             order: 999;
         }
 
         .scroller-wrap {
             width: 100%;
+            .scroller {
+                overflow-x: scroll;
+                overflow-y: hidden;
+            }
         }
 
         // Sort of a hack, but it's pretty useless and just obscures the view
@@ -388,11 +392,5 @@
 @if ($hide-unread-mentions-bar) {
     div[class*="unreadMentionsBar-"] {
         display: none;
-    }
-}
-
-@if ($server-list-above and $server-list-above-enable-scrollbar) {
-    .scroller-wrap .scroller {
-        overflow-x: scroll;
     }
 }

--- a/tweaks/_main_code.scss
+++ b/tweaks/_main_code.scss
@@ -56,7 +56,7 @@
 
     div[class*="guildsWrapper-"] {
         width: 100%;
-        height: 75px;
+        height: 100px;
         @if ($server-list-above-below) {
             order: 999;
         }
@@ -382,5 +382,17 @@
     .app + div[style="opacity: 1;"] {
         //opacity: 0.25!important;
         display: none;
+    }
+}
+
+@if ($hide-unread-mentions-bar) {
+    div[class*="unreadMentionsBar-"] {
+        display: none;
+    }
+}
+
+@if ($server-list-above and $server-list-above-enable-scrollbar) {
+    .scroller-wrap .scroller {
+        overflow-x: scroll;
     }
 }

--- a/tweaks/_variables.scss
+++ b/tweaks/_variables.scss
@@ -9,7 +9,6 @@ $web-hide-download-button: false;// Hides the download button in the web client
 $alternative-user-popup: false; // Changes the look and feel of the user popup 
 $compact-mode-tweaks: false;    // Makes compact mode more compact, among other things
 $hide-unread-mentions-bar: false;// 'unread mentions' bar can get in the way when using horizontal server list
-$server-list-above-enable-scrollbar: false;// Adds a horizontal scrollbar to the server list
 
 
 // Settings

--- a/tweaks/_variables.scss
+++ b/tweaks/_variables.scss
@@ -8,6 +8,8 @@ $code-block-images: false;      // Adds the programming languages logo to code b
 $web-hide-download-button: false;// Hides the download button in the web client
 $alternative-user-popup: false; // Changes the look and feel of the user popup 
 $compact-mode-tweaks: false;    // Makes compact mode more compact, among other things
+$hide-unread-mentions-bar: false;// 'unread mentions' bar can get in the way when using horizontal server list
+$server-list-above-enable-scrollbar: false;// Adds a horizontal scrollbar to the server list
 
 
 // Settings


### PR DESCRIPTION
I've added two new tweaks:

`$server-list-above-enable-scrollbar` - displays a horizontal scrollbar if `$server-list-above` is also set to true
`$hide-unread-mentions-bar` - hides the unread mentions bar, which can get in the way when using a horizontal server list